### PR TITLE
Restore "load epg" log message and level

### DIFF
--- a/status.c
+++ b/status.c
@@ -356,7 +356,7 @@ void cVNSIStatus::Action(void)
 			{
 				if ( epgState.isModified() )
 				{
-					INFOLOG("Requesting clients to reload timers");
+					DEBUGLOG("Requesting clients to load epg");
 					lock.lock();
 					std::for_each( m_clients.begin(), m_clients.end(),
 					               [](const cVNSIClientSharedPtr& client)


### PR DESCRIPTION
This message can occur every 5 seconds.

Restoring message and level from before:
e3ae587 ("VNSIClient: Reworked threading", 2020-12-27)