### PR TITLE
Fix crash when epg has no title

### DIFF
--- a/vnsitimer.c
+++ b/vnsitimer.c
@@ -449,6 +449,9 @@ void CVNSITimers::Action()
             if (event->EndTime() < time(nullptr))
               continue;
 
+            if (event->Title() == nullptr)
+              continue;
+
             std::string title(event->Title());
             std::smatch m;
             std::regex e(Convert(searchTimer.m_search));


### PR DESCRIPTION
This was the reported error:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
```

Here is a backtrace of std::__throw_logic_error():
```
    #0 0x7f44aea2d919 in __sanitizer_print_stack_trace (/usr/lib64/libasan.so.6+0xbc919)
    #1 0x7f44a23ac14e in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/include/c++/11.3.0/bits/basic_string.tcc:220
    #2 0x7f44a23f1911 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> >(char const*, std::allocator<char> const&) /usr/include/c++/11.3.0/bits/basic_string.h:539
    #3 0x7f44a23f1911 in CVNSITimers::Action() vnsiserver-f90067db10973bac36ac59f7105523dd66c0dd55/vnsitimer.c:452
    #4 0xd6314a in cThread::StartThread(cThread*) vdr-2.4.7/thread.c:293
    #5 0x7f44ad9d4535  (/lib64/libc.so.6+0x85535)
    #6 0x7f44ada56dfb  (/lib64/libc.so.6+0x107dfb)
```