### PR TITLE
Add last changes from vnsiserver crash thread

### DIFF
--- a/vnsiclient.c
+++ b/vnsiclient.c
@@ -1201,12 +1201,13 @@ bool cVNSIClient::processCHANNELS_GetChannels(cRequestPacket &req) /* OPCODE 63 
        }
 
      StateKey.Remove();
+
+     resp.finalise();
+     m_socket.write(resp.getPtr(), resp.getLen());
+     return true;
      }
 
-  resp.finalise();
-  m_socket.write(resp.getPtr(), resp.getLen());
-
-  return true;
+  return false;
 }
 
 bool cVNSIClient::processCHANNELS_GroupsCount(cRequestPacket &req)


### PR DESCRIPTION
Hi,

this patch adds the last change from this VDR thread, dealing with crashes in vnsiserver plus vdr-2.6.6

https://www.vdr-portal.de/forum/index.php?thread/136064-compile-warnings-in-vnsiserver/&postID=1368396#post1368396