### PR TITLE
VNSISocket cleanup fixes

### DIFF
--- a/vnsisocket.c
+++ b/vnsisocket.c
@@ -13,6 +13,7 @@
 #include "StatusCommands.h"
 
 #include <memory>
+#include <cxxabi.h>
 
 #include <arpa/inet.h>
 
@@ -53,7 +54,7 @@ VNSISocket::unlock()
 void
 VNSISocket::Invalidate()
 {
-	Cancel( -1 );
+	Cancel( 0 );
 	m_socket.Invalidate();
 }
 
@@ -146,6 +147,10 @@ VNSISocket::Action()
 	{
 		ERRORLOG( "Socket error: '%s'. Dropping connection", error.what() );
 		m_queue.enqueue( std::make_shared<SocketError>() );
+	}
+	catch ( abi::__forced_unwind& )
+	{
+		throw;
 	}
 	catch ( ... )
 	{

--- a/vnsisocket.c
+++ b/vnsisocket.c
@@ -99,7 +99,12 @@ VNSISocket::Action()
 			// Read the header. It is fixed site and contains the remaining
 			// bytes to read.
 			Header header;
-			if ( sizeof(header) != m_socket.read(&header, sizeof(header)) )
+			ssize_t headerLength = m_socket.read(&header, sizeof(header));
+			if (headerLength == 0)
+			{
+				return;
+			}
+			else if ( sizeof(header) != headerLength )
 			{
 				throw std::runtime_error( "Failed to read header" );
 			}


### PR DESCRIPTION
These two are need to resolve 3 error messages so far thrown on each channel switch.

See also https://www.vdr-portal.de/forum/thread/137146-vnsiserver-error-spamming-bei-kanalwechsel/